### PR TITLE
add apollo-link peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "README.md"
   ],
   "dependencies": {
+    "apollo-link": "^0.7.0",
     "apollo-link-http": "^0.7.0",
     "graphql": "^0.11.2",
     "graphql-request": "^1.3.4",


### PR DESCRIPTION
fixes this warning:

![image](https://user-images.githubusercontent.com/1780597/31864019-c559e0ae-b756-11e7-9ef9-9d430d2eb8a5.png)
